### PR TITLE
Fix issues #3, #5, #6

### DIFF
--- a/src/AsyncMQTT.h
+++ b/src/AsyncMQTT.h
@@ -123,6 +123,7 @@ class AsyncMQTT {
                void            _onData(uint8_t* data, size_t len,bool synthetic=false);
                void            _onDisconnect(int8_t r);
                void            _onPoll(AsyncClient* client);
+               void            _onTimeout(AsyncClient* client, uint32_t time);
     public:
         AsyncMQTT();
 
@@ -148,7 +149,7 @@ class AsyncMQTT {
         static void            dumphex(const void *mem, uint32_t len, uint8_t cols=16);
                const char*     getClientId(){ return _clientId.c_str(); }
                uint16_t        publish(const char* topic, uint8_t qos, bool retain, uint8_t* payload = nullptr, size_t length = 0, bool dup = false);
-               uint16_t        publish(const char* topic, uint8_t qos, bool retain, std::string payload){ publish(topic,qos,retain, (uint8_t*) payload.data(), payload.size()); }
+               uint16_t        publish(const char* topic, uint8_t qos, bool retain, std::string payload){ return publish(topic,qos,retain, (uint8_t*) payload.data(), payload.size()); }
                uint16_t        subscribe(const char* topic, uint8_t qos);
                uint16_t        unsubscribe(const char* topic);
 

--- a/src/Packet.h
+++ b/src/Packet.h
@@ -39,6 +39,8 @@ class Packet {
     friend class AsyncMQTT;
         static  std::queue<ADFP>  _flowControl;
     protected:
+
+        static  bool             _pcb_busy;
         static  ADFP             _unAcked;
         static  uint16_t         _uaId;
         static  uint16_t         _nextId;
@@ -76,7 +78,7 @@ class Packet {
                 uint8_t*         _stringblock(const std::string& s){ return _mem(s.data(),s.size()); }
             
     public:
-        Packet(uint8_t controlcode,uint8_t adj=0,bool hasid=false): _controlcode(controlcode),_hdrAdjust(adj),_hasId(hasid){}
+        Packet(uint8_t controlcode,uint8_t adj=0,bool hasid=false): _hdrAdjust(adj),_hasId(hasid),_controlcode(controlcode){}
         virtual ~Packet();
 
     static  void        ACKinbound(uint16_t id){ _ACK(&_inbound,id); }
@@ -116,7 +118,7 @@ class SubscribePacket: public Packet {
         std::string          _topic;
     public:
         uint8_t         _qos;
-        SubscribePacket(const std::string& topic,uint8_t qos): _topic(topic),_qos(qos),Packet(SUBSCRIBE,1,true) {
+        SubscribePacket(const std::string& topic,uint8_t qos): Packet(SUBSCRIBE,1,true),_topic(topic),_qos(qos) {
             _id=++_nextId;
             _begin=[this]{ _stringblock(CSTR(_topic)); };
             _end=[this](uint8_t* p,ADFP base){ *p=_qos; };
@@ -126,7 +128,7 @@ class SubscribePacket: public Packet {
 class UnsubscribePacket: public Packet {
         std::string          _topic;
     public:
-        UnsubscribePacket(const std::string& topic): _topic(topic),Packet(UNSUBSCRIBE,1,false) {
+        UnsubscribePacket(const std::string& topic): Packet(UNSUBSCRIBE,1,false),_topic(topic) {
             _id=++_nextId;
             _begin=[this]{ _stringblock(CSTR(_topic)); };
             _build();


### PR DESCRIPTION
These issues are fixed with this PR:

#3 (Feedback for v0.0.3 dirty )
-> less compiler warnings and errors mainly with ESP32 in platformIO
-> change _poke16(p,id);to_poke16(&p[2],id); for PubackPacket

#5 (TCP ACK missing for ESP32)
-> correct TCP ACK handling with ESP32 AsyncTCP

#6 (Crash when disconnect manually)
-> no more crashes with manual disconnect

